### PR TITLE
add automated dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/backend"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
unfortunately not yet available for flutter dependencies --> only for our github actions and the nuget dependencies of the backend for now