### PR TITLE
Greedy skill-based team assigner

### DIFF
--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using backend.Rating;
+
+namespace backend
+{
+    public class SkillBasedAssigner : ITeamAssigner
+    {
+        IList<Player> ITeamAssigner.GetAssignedPlayers(IEnumerable<Player> players)
+        {
+            foreach (var player in players)
+            {
+                GetSkillLevel(player);
+            }
+
+            var sortedByScore = players.OrderByDescending(x => x.Skill.SkillScore).ToList();
+            var bestPlayerIsTerrorist = new Random().NextDouble() < 0.5;
+
+            for (var i = 0; i < sortedByScore.Count; i++)
+            {
+                var currentPlayer = sortedByScore[i];
+
+                if (i % 2 == 0)
+                {
+                    currentPlayer.Team = bestPlayerIsTerrorist ? Team.Terrorists : Team.CounterTerrorists;
+                }
+                else
+                {
+                    currentPlayer.Team = bestPlayerIsTerrorist ? Team.CounterTerrorists : Team.Terrorists;
+                }
+            }
+
+            return sortedByScore;
+        }
+
+        private static void GetSkillLevel(Player player)
+        {
+            var hltvRating = new HLTVRating();
+            hltvRating.ScrapeForPlayer(player.SteamID);
+            player.Skill.AddRating(hltvRating);
+        }
+    }
+}


### PR DESCRIPTION
Assigning teams based on a score as we'd like to do in our first iteration is a partition problem, often called **the easiest NP-hard problem**.

As we're not dealing with huge `n` or are concerned with always finding an optimal solution, a simple greedy algorithm should be sufficient for now.

Basically, we sort all players descending by their score and then go through that sorted list and alternate team assignments.
The first team, i.e., the team the best player will be assigned to, is randomly selected at runtime.
