### PR TITLE
Removal of "Name" property in Player API

### DIFF
--- a/backend/Controllers/PlayerController.cs
+++ b/backend/Controllers/PlayerController.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 
 namespace backend.Controllers
 {

--- a/backend/Controllers/PlayerController.cs
+++ b/backend/Controllers/PlayerController.cs
@@ -18,11 +18,6 @@ namespace backend.Controllers
         [HttpPost]
         public Assignment GetAssignedTeams(IEnumerable<Player> players)
         {
-            foreach (var player in players)
-            {
-                player.ScrapeName();
-            }
-
             (Team terrorists, Team counterTerrorists) = myAssigner.GetAssignedPlayers(players);
             return new Assignment(terrorists, counterTerrorists);
         }

--- a/backend/Player.cs
+++ b/backend/Player.cs
@@ -1,11 +1,12 @@
+using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Net;
-using Newtonsoft.Json;
 
 namespace backend
 {
-    public class Player {
+    public class Player
+    {
         private const string steamAPIKey = "B0E3E0ED2572C01223E0ED7043E9678C";
         public string Name { get; set; }
 
@@ -33,7 +34,7 @@ namespace backend
                 using (var sr = new StreamReader(s))
                 {
                     dynamic json = JsonConvert.DeserializeObject(sr.ReadToEnd());
-                    
+
                     if (json.response.players.Count != 1)
                     {
                         throw new ArgumentException($"The SteamID ({SteamID}) you provided could not be found. Please check the player's Steam community profile URL.");

--- a/backend/Player.cs
+++ b/backend/Player.cs
@@ -7,43 +7,8 @@ namespace backend
 {
     public class Player
     {
-        private const string steamAPIKey = "B0E3E0ED2572C01223E0ED7043E9678C";
-        public string Name { get; set; }
-
         public string SteamID { get; set; }
 
         public SkillLevel Skill { get; set; }
-
-        public void ScrapeName()
-        {
-            if (string.IsNullOrEmpty(SteamID))
-            {
-                throw new InvalidOperationException("The SteamID has to be set to scrape the player's name.");
-            }
-
-            var webRequest = WebRequest.Create($"https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={steamAPIKey}&steamids={SteamID}");
-            if (webRequest == null)
-            {
-                return;
-            }
-
-            webRequest.ContentType = "application/json";
-
-            using (var s = webRequest.GetResponse().GetResponseStream())
-            {
-                using (var sr = new StreamReader(s))
-                {
-                    dynamic json = JsonConvert.DeserializeObject(sr.ReadToEnd());
-
-                    if (json.response.players.Count != 1)
-                    {
-                        throw new ArgumentException($"The SteamID ({SteamID}) you provided could not be found. Please check the player's Steam community profile URL.");
-                    }
-
-                    string profileName = json.response.players[0].personaname;
-                    Name = profileName.Replace("'", "");
-                }
-            }
-        }
     }
 }

--- a/backend/Player.cs
+++ b/backend/Player.cs
@@ -1,8 +1,3 @@
-using Newtonsoft.Json;
-using System;
-using System.IO;
-using System.Net;
-
 namespace backend
 {
     public class Player

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -1,7 +1,7 @@
+using backend.Rating;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using backend.Rating;
 
 namespace backend
 {

--- a/backend/SkillLevel.cs
+++ b/backend/SkillLevel.cs
@@ -1,14 +1,12 @@
+using backend.Rating;
 using System;
-
 using System.Collections.Generic;
 using System.Linq;
-
-using backend.Rating;
 
 namespace backend
 {
     public class SkillLevel : IComparable
-    {        
+    {
         private readonly IList<IRating> myRatings;
 
         public double SkillScore => myRatings.Average(x => x.Score);

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 
 namespace backend

--- a/backend/Team.cs
+++ b/backend/Team.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 
 namespace backend


### PR DESCRIPTION
As we currently use a hardcoded list of players (in the frontend), with real name & steamid, scraping the current steam user name doesn't make any sense.

If/when we implement the feature requested in #29 this scraping code might be re-used -> linking it here 🚀

@michaelsandner this also changes the REST API -> you can add the required changes to the frontend to this dev branch/pull request so we can merge it together (☞ﾟヮﾟ)☞