### PR TITLE
Optimal assignment solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # .NET Core build folders
 bin/
 obj/
+backend.csproj.user
+.dtbcache.v2
+.suo
+applicationhost.config
 
 # Common node modules locations
 /node_modules

--- a/backend/Controllers/PlayerController.cs
+++ b/backend/Controllers/PlayerController.cs
@@ -21,6 +21,7 @@ namespace backend.Controllers
         public async Task<Assignment> GetAssignedTeams(IEnumerable<Player> players)
         {
             var playersWithSteamNames = await SteamworksApi.SteamworksApi.ParseSteamUsernames(players.ToList());
+            (Team terrorists, Team counterTerrorists) = await myAssigner.GetAssignedPlayers(playersWithSteamNames);
             return new Assignment(terrorists, counterTerrorists);
         }
     }

--- a/backend/Controllers/PlayerController.cs
+++ b/backend/Controllers/PlayerController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace backend.Controllers
 {
@@ -17,10 +18,9 @@ namespace backend.Controllers
         }
 
         [HttpPost]
-        public Assignment GetAssignedTeams(IEnumerable<Player> players)
+        public async Task<Assignment> GetAssignedTeams(IEnumerable<Player> players)
         {
-            var playersWithSteamNames = SteamworksApi.SteamworksApi.ParseSteamUsernames(players.ToList());
-            (Team terrorists, Team counterTerrorists) = myAssigner.GetAssignedPlayers(playersWithSteamNames);
+            var playersWithSteamNames = await SteamworksApi.SteamworksApi.ParseSteamUsernames(players.ToList());
             return new Assignment(terrorists, counterTerrorists);
         }
     }

--- a/backend/ITeamAssigner.cs
+++ b/backend/ITeamAssigner.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace backend
 {
     public interface ITeamAssigner
     {
-        (Team terrorists, Team counterTerrorists) GetAssignedPlayers(IEnumerable<Player> players);
+        Task<(Team terrorists, Team counterTerrorists)> GetAssignedPlayers(IEnumerable<Player> players);
     }
 }

--- a/backend/Player.cs
+++ b/backend/Player.cs
@@ -1,9 +1,3 @@
-using Newtonsoft.Json;
-using System;
-using System.IO;
-using System.Linq;
-using System.Net;
-
 namespace backend
 {
     public class Player

--- a/backend/ProfileNotPublicException.cs
+++ b/backend/ProfileNotPublicException.cs
@@ -3,5 +3,5 @@ using System;
 namespace backend
 {
     public class ProfileNotPublicException : Exception
-    {}
+    { }
 }

--- a/backend/Rating/HLTVRating.cs
+++ b/backend/Rating/HLTVRating.cs
@@ -1,4 +1,3 @@
-using System;
 namespace backend.Rating
 {
     public class HLTVRating : IRating

--- a/backend/Rating/KDRating.cs
+++ b/backend/Rating/KDRating.cs
@@ -1,3 +1,5 @@
+using backend.SteamworksApi;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace backend.Rating
@@ -7,10 +9,8 @@ namespace backend.Rating
         public string Name => "KD";
         public double Score { get; }
 
-        public KDRating(string steamID)
+        public KDRating(IEnumerable<Statistic> playerStatistics)
         {
-            var playerStatistics = SteamworksApi.SteamworksApi.ParsePlayerStatistics(steamID);
-            
             var kills = playerStatistics.SingleOrDefault(x => x.Name == "total_kills").Value;
             var deaths = playerStatistics.SingleOrDefault(x => x.Name == "total_deaths").Value;
 

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -70,8 +70,6 @@ namespace backend
                 }
             }
 
-            (terrorists, counterTerrorists) = ScrambleTeams(terrorists, counterTerrorists, 0.1);
-
             return (terrorists, counterTerrorists);
         }
 
@@ -88,29 +86,6 @@ namespace backend
                 player.Skill.AddRating(new DummyRating { Score = Double.MaxValue });
                 player.ProfilePublic = false;
             }
-        }
-
-        private static (Team terrorists, Team counterTerrorists) ScrambleTeams(Team terrorists, Team counterTerrorists, double scrambleProbability)
-        {
-            var random = new Random();
-
-            for (var i = 0; i < terrorists.Players.Count; i++)
-            {
-                var scramble = random.NextDouble() > scrambleProbability;
-
-                if (scramble)
-                {
-                    var terrorist = terrorists.Players[i];
-                    var counterTerrorist = counterTerrorists.Players[i];
-                    terrorists.Players.Remove(terrorist);
-                    counterTerrorists.Players.Remove(counterTerrorist);
-
-                    terrorists.Players.Insert(i, counterTerrorist);
-                    counterTerrorists.Players.Insert(i, terrorist);
-                }
-            }
-
-            return (terrorists, counterTerrorists);
         }
     }
 }

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -51,7 +51,20 @@ namespace backend
                 sortedByScore[1] = bestPlayer;
             }
 
-            return GreedyAssigner(sortedByScore);
+            var terrorists = new Team("Terrorists");
+            var counterTerrorists = new Team("CounterTerrorists");
+
+            switch (option)
+            {
+                case SolverOptions.Optimal:
+                    (terrorists, counterTerrorists) = OptimalAssigner(sortedByScore, 0.1);
+                    break;
+                case SolverOptions.Greedy:
+                    (terrorists, counterTerrorists) = GreedyAssigner(sortedByScore);
+                    break;
+            }
+
+            return (terrorists, counterTerrorists);
         }
 
         private static (Team terrorists, Team counterTerrorists) GreedyAssigner(IEnumerable<Player> playersSortedByScore)

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -6,11 +6,20 @@ using System.Threading.Tasks;
 
 namespace backend
 {
+    public enum SolverOptions
+    {
+        Greedy,
+        Optimal
+    }
+
     public class SkillBasedAssigner : ITeamAssigner
     {
-        (Team terrorists, Team counterTerrorists) ITeamAssigner.GetAssignedPlayers(IEnumerable<Player> players)
+        public async Task<(Team terrorists, Team counterTerrorists)> GetAssignedPlayers(IEnumerable<Player> players)
         {
-        private static async Task<(Team terrorists, Team counterTerrorists)> GetAssignedPlayers(IEnumerable<Player> players)
+            return await GetAssignedPlayers(players, SolverOptions.Optimal);
+        }
+
+        private static async Task<(Team terrorists, Team counterTerrorists)> GetAssignedPlayers(IEnumerable<Player> players, SolverOptions option)
         {
             var playersList = players.ToList();
 

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -77,7 +77,8 @@ namespace backend
         {
             try
             {
-                var kdRating = new KDRating(player.SteamID);
+                var playerStatistics = SteamworksApi.SteamworksApi.ParsePlayerStatistics(player.SteamID);
+                var kdRating = new KDRating(playerStatistics);
                 player.Skill.AddRating(kdRating);
                 player.ProfilePublic = true;
             }

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -50,6 +50,13 @@ namespace backend
                 sortedByScore[1] = bestPlayer;
             }
 
+            return GreedyAssigner(sortedByScore);
+        }
+
+        private static (Team terrorists, Team counterTerrorists) GreedyAssigner(IEnumerable<Player> playersSortedByScore)
+        {
+            var sortedByScore = playersSortedByScore.ToList();
+
             var bestPlayerIsTerrorist = new Random().NextDouble() < 0.5;
 
             var terrorists = new Team("Terrorists");

--- a/backend/SkillBasedAssigner.cs
+++ b/backend/SkillBasedAssigner.cs
@@ -42,7 +42,8 @@ namespace backend
                     Skill = new SkillLevel()
                 };
 
-                bot.Skill.AddRating(new DummyRating { Score = 0.0d });
+                var averageScoreHumanPlayers = sortedByScore.Average(x => x.Skill.SkillScore);
+                bot.Skill.AddRating(new DummyRating { Score = averageScoreHumanPlayers / 2.0 });
 
                 sortedByScore.Add(bot);
                 var bestPlayer = sortedByScore[0];

--- a/backend/SteamworksApi/PlayerSummaries.cs
+++ b/backend/SteamworksApi/PlayerSummaries.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace backend.SteamworksApi
 {

--- a/backend/SteamworksApi/SteamworksApi.cs
+++ b/backend/SteamworksApi/SteamworksApi.cs
@@ -34,14 +34,15 @@ namespace backend.SteamworksApi
             return players;
         }
 
-        public static IList<Statistic> ParsePlayerStatistics(string steamID)
+        public static async Task<IList<Statistic>> ParsePlayerStatistics(string steamID)
         {
             var webRequest = WebRequest.Create($"https://api.steampowered.com/ISteamUserStats/GetUserStatsForGame/v2/?appid=730&key={steamAPIKey}&steamid={steamID}");
             webRequest.ContentType = "application/json";
 
             try
             {
-                using var responseStream = webRequest.GetResponse().GetResponseStream();
+                using var response = await webRequest.GetResponseAsync();
+                using var responseStream = response.GetResponseStream();
                 using var responseStreamReader = new StreamReader(responseStream);
 
                 return JsonConvert.DeserializeObject<PlayerStatistics>(responseStreamReader.ReadToEnd()).Statistics.Stats;

--- a/backend/SteamworksApi/SteamworksApi.cs
+++ b/backend/SteamworksApi/SteamworksApi.cs
@@ -1,8 +1,9 @@
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace backend.SteamworksApi
 {
@@ -10,14 +11,15 @@ namespace backend.SteamworksApi
     {
         private const string steamAPIKey = "B0E3E0ED2572C01223E0ED7043E9678C";
 
-        public static IList<Player> ParseSteamUsernames(IList<Player> players)
+        public static async Task<IList<Player>> ParseSteamUsernames(IList<Player> players)
         {
             var commaDelimitedSteamIDs = string.Join(",", players.Select(x => x.SteamID));
 
             var webRequest = WebRequest.Create($"https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={steamAPIKey}&steamids={commaDelimitedSteamIDs}");
             webRequest.ContentType = "application/json";
 
-            using var responseStream = webRequest.GetResponse().GetResponseStream();
+            using var response = await webRequest.GetResponseAsync();
+            using var responseStream = response.GetResponseStream();
             using var responseStreamReader = new StreamReader(responseStream);
 
             var parsedResponse = JsonConvert.DeserializeObject<GetPlayerSummariesResponse>(responseStreamReader.ReadToEnd());

--- a/backend/SteamworksApi/UserStats.cs
+++ b/backend/SteamworksApi/UserStats.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace backend.SteamworksApi
 {
@@ -7,7 +7,7 @@ namespace backend.SteamworksApi
     {
         [JsonProperty("name")]
         public string Name { get; set; }
-        
+
         [JsonProperty("value")]
         public int Value { get; set; }
     }

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Combinatorics" Version="1.1.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />


### PR DESCRIPTION
This PR adds an alternative to the currently used greedy solver for the skill-based assignment.

Through some statistics tricks the complexity of the problem could be reduced significantly. Additional multithreading and some (somewhat unrelated) asynchronicity allow for still acceptable runtimes, even on our low-powered linode VM running the backend.

Still to do/follow up:

* We now have a list of team assignments in a descending order of fairness. It would be great to go through that list whenever the user clicks the "ScrambleApi" button again to get a slightly different but still fair assignment. Currently this is implemented by selecting the best/fairest assignments, based on a cutoff value of 0.1 for the skill difference between the teams, and randomly returning one of those assignments. Already in discussion with @michaelsandner regarding cleaner solutions. If we stick with this approach, the value of 0.1 has to be refined.
* To make the assignments more fair with unbalanced human players, the skill of the bot is now set at 1/2 the average human skill score. This value also has to be refined.