### PR TITLE
Reduced REST Api

### DIFF
--- a/backend/fairTeams.API/Controllers/FairTeamsController.cs
+++ b/backend/fairTeams.API/Controllers/FairTeamsController.cs
@@ -1,0 +1,60 @@
+﻿using fairTeams.Steamworks;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace fairTeams.API.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    [EnableCors]
+    public class FairTeamsController : ControllerBase
+    {
+        private readonly ITeamAssigner myAssigner;
+        private readonly ILogger myLogger;
+
+        public FairTeamsController(ITeamAssigner teamAssigner, ILogger<FairTeamsController> logger)
+        {
+            myAssigner = teamAssigner;
+            myLogger = logger;
+        }
+
+        [HttpPost]
+        public async Task<Assignment> GetAssignedTeams(IEnumerable<RequestPlayer> players)
+        {
+            players = await SetSteamUsernames(players);
+
+            (Team terrorists, Team counterTerrorists) = await myAssigner.GetAssignedPlayers(Convert(players));
+
+            return new Assignment(terrorists, counterTerrorists);
+        }
+
+        private async Task<IEnumerable<RequestPlayer>> SetSteamUsernames(IEnumerable<RequestPlayer> players)
+        {
+            var steamIDsWithUsernames = await SteamworksApi.ParseSteamUsernames(players.Select(x => x.SteamID).ToList());
+
+            foreach (var player in players)
+            {
+                player.SteamName = steamIDsWithUsernames.SingleOrDefault(x => x.Key == player.SteamID).Value;
+            }
+
+            foreach (var notFoundPlayer in players.Where(x => string.IsNullOrEmpty(x.SteamName)))
+            {
+                myLogger.LogWarning($"Player's {notFoundPlayer.Name} Steam ID ({notFoundPlayer.SteamID}) seems to be invalid.");
+            }
+
+            return players;
+        }
+
+        private static IEnumerable<Player> Convert(IEnumerable<RequestPlayer> requestPlayers)
+        {
+            foreach (var requestPlayer in requestPlayers)
+            {
+                yield return new Player(requestPlayer);
+            }
+        }
+    }
+}

--- a/backend/fairTeams.API/Controllers/PlayerController.cs
+++ b/backend/fairTeams.API/Controllers/PlayerController.cs
@@ -2,6 +2,7 @@ using fairTeams.Steamworks;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -12,6 +13,7 @@ namespace fairTeams.API.Controllers
     [ApiController]
     [Route("[controller]")]
     [EnableCors]
+    [Obsolete("Please use the /FairTeams endpoint instead")]
     public class PlayerController : ControllerBase
     {
         private readonly ITeamAssigner myAssigner;

--- a/backend/fairTeams.API/Player.cs
+++ b/backend/fairTeams.API/Player.cs
@@ -1,11 +1,30 @@
+using System;
+
 namespace fairTeams.API
 {
     public class Player
     {
         public string Name { get; set; }
         public string SteamName { get; set; }
+        [Obsolete("Please do not use anymore.")]
         public bool ProfilePublic { get; set; }
         public string SteamID { get; set; }
         public SkillLevel Skill { get; set; }
+
+        public Player() { }
+
+        public Player(RequestPlayer obj)
+        {
+            Name = obj.Name;
+            SteamName = obj.SteamName;
+            SteamID = obj.SteamID;
+        }
+    }
+
+    public class RequestPlayer
+    {
+        public string Name { get; set; }
+        public string SteamName { get; set; }
+        public string SteamID { get; set; }
     }
 }

--- a/backend/fairTeams.API/Player.cs
+++ b/backend/fairTeams.API/Player.cs
@@ -16,7 +16,6 @@ namespace fairTeams.API
         public Player(RequestPlayer obj)
         {
             Name = obj.Name;
-            SteamName = obj.SteamName;
             SteamID = obj.SteamID;
         }
     }
@@ -24,7 +23,6 @@ namespace fairTeams.API
     public class RequestPlayer
     {
         public string Name { get; set; }
-        public string SteamName { get; set; }
         public string SteamID { get; set; }
     }
 }


### PR DESCRIPTION
Closing #63, this provides a new and reduced Rest API behind the `/FairTeams` endpoint.

The old controller is still available for now but set to obsolete. Same goes for the "profilePublic" return property.
Both will be removed once the frontend doesn't depend on it anymore.