### PR TITLE
Proper fallback-enabled skill score computation

### DIFF
--- a/backend/fairTeams.API.Tests/SkillBasedAssignerTests.cs
+++ b/backend/fairTeams.API.Tests/SkillBasedAssignerTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using fairTeams.Core;
+using fairTeams.Steamworks;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -31,7 +32,7 @@ namespace fairTeams.API.Tests
             match.PlayerResults.Add(new MatchStatistics { SteamID = 2, Id = "2", Kills = 2, Deaths = 2 });
             myMatchRepository.Add(match);
             myMatchRepository.SaveChanges();
-            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository);
+            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository, new SteamworksApi());
 
             (var t, var ct) = await skillBasedAssigner.GetAssignedPlayers(new List<Player> { new Player { SteamID = "1" }, new Player { SteamID = "2" } });
 
@@ -48,7 +49,7 @@ namespace fairTeams.API.Tests
             match.PlayerResults.Add(new MatchStatistics { SteamID = 3, Id = "3", Kills = 3, Deaths = 3 });
             myMatchRepository.Add(match);
             myMatchRepository.SaveChanges();
-            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository);
+            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository, new SteamworksApi());
 
             (var t, var ct) = await skillBasedAssigner.GetAssignedPlayers(new List<Player> { 
                 new Player { SteamID = "1", Name = "Emma"}, 
@@ -74,7 +75,7 @@ namespace fairTeams.API.Tests
             match.PlayerResults.Add(new MatchStatistics { SteamID = 4, Id = Guid.NewGuid().ToString(), Kills = 2, Deaths = 3, Rounds = 5 });
             myMatchRepository.Add(match);
             myMatchRepository.SaveChanges();
-            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository);
+            var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository, new SteamworksApi());
 
             (var t, var ct) = await skillBasedAssigner.GetAssignedPlayers(new List<Player> { strongPlayer1, strongPlayer2, mediumPlayer1, mediumPlayer2 });
 

--- a/backend/fairTeams.API.Tests/SkillBasedAssignerTests.cs
+++ b/backend/fairTeams.API.Tests/SkillBasedAssignerTests.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using fairTeams.Core;
+﻿using fairTeams.Core;
 using fairTeams.Steamworks;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
-
 using Match = fairTeams.Core.Match;
 
 namespace fairTeams.API.Tests
@@ -52,9 +51,9 @@ namespace fairTeams.API.Tests
             myMatchRepository.SaveChanges();
             var skillBasedAssigner = new SkillBasedAssigner(myMatchRepository, new SteamworksApi());
 
-            (var t, var ct) = await skillBasedAssigner.GetAssignedPlayers(new List<Player> { 
-                new Player { SteamID = "1", Name = "Emma"}, 
-                new Player { SteamID = "2", Name = "Kathy"}, 
+            (var t, var ct) = await skillBasedAssigner.GetAssignedPlayers(new List<Player> {
+                new Player { SteamID = "1", Name = "Emma"},
+                new Player { SteamID = "2", Name = "Kathy"},
                 new Player { SteamID = "3", Name = "Baltasar" } });
 
             Assert.Equal(2, t.Players.Count);
@@ -92,7 +91,7 @@ namespace fairTeams.API.Tests
             var steamworksApiMock = new Mock<SteamworksApi>();
             steamworksApiMock
                 .Setup(x => x.ParsePlayerStatistics(It.IsAny<string>()))
-                .Returns(Task.FromResult((IList<Statistic>) new List<Statistic> {
+                .Returns(Task.FromResult((IList<Statistic>)new List<Statistic> {
                     new Statistic {Name = "total_kills", Value = 5 },
                     new Statistic {Name = "total_deaths", Value = 1 }
                  }));

--- a/backend/fairTeams.API/Controllers/FairTeamsController.cs
+++ b/backend/fairTeams.API/Controllers/FairTeamsController.cs
@@ -14,11 +14,13 @@ namespace fairTeams.API.Controllers
     public class FairTeamsController : ControllerBase
     {
         private readonly ITeamAssigner myAssigner;
+        private readonly SteamworksApi mySteamworksApi;
         private readonly ILogger myLogger;
 
-        public FairTeamsController(ITeamAssigner teamAssigner, ILogger<FairTeamsController> logger)
+        public FairTeamsController(ITeamAssigner teamAssigner, SteamworksApi steamworksApi, ILogger<FairTeamsController> logger)
         {
             myAssigner = teamAssigner;
+            mySteamworksApi = steamworksApi;
             myLogger = logger;
         }
 
@@ -34,7 +36,7 @@ namespace fairTeams.API.Controllers
 
         private async Task<IEnumerable<Player>> GetSteamUsernames(IEnumerable<RequestPlayer> players)
         {
-            var steamIDsWithUsernames = await SteamworksApi.ParseSteamUsernames(players.Select(x => x.SteamID).ToList());
+            var steamIDsWithUsernames = await mySteamworksApi.ParseSteamUsernames(players.Select(x => x.SteamID).ToList());
             var extendedPlayers = new List<Player>();
 
             foreach (var player in players)

--- a/backend/fairTeams.API/Rating/HLTVRating.cs
+++ b/backend/fairTeams.API/Rating/HLTVRating.cs
@@ -10,7 +10,8 @@ namespace fairTeams.API.Rating
 
         public HLTVRating(long steamID, MatchRepository matchRepository)
         {
-            Score = matchRepository.Matches.SelectMany(x => x.PlayerResults).Where(y => y.SteamID == steamID).ToList().Average(z => z.HLTVScore);
+            var allMatchStatisticsForPlayer = matchRepository.GetAllMatchStatisticsForSteamId(steamID);
+            Score = allMatchStatisticsForPlayer.Average(z => z.HLTVScore);
         }
     }
 }

--- a/backend/fairTeams.API/SkillBasedAssigner.cs
+++ b/backend/fairTeams.API/SkillBasedAssigner.cs
@@ -13,15 +13,17 @@ namespace fairTeams.API
     public class SkillBasedAssigner : ITeamAssigner
     {
         private readonly MatchRepository myMatchRepository;
+        private readonly SteamworksApi mySteamworksApi;
         private readonly ILogger myLogger;
 
-        public SkillBasedAssigner(MatchRepository matchRepository, ILogger<SkillBasedAssigner> logger)
+        public SkillBasedAssigner(MatchRepository matchRepository, SteamworksApi steamworksApi, ILogger<SkillBasedAssigner> logger)
         {
             myMatchRepository = matchRepository;
+            mySteamworksApi = steamworksApi;
             myLogger = logger;
         }
 
-        public SkillBasedAssigner(MatchRepository matchRepository) : this(matchRepository, UnitTestLoggerCreator.CreateUnitTestLogger<SkillBasedAssigner>()) { }
+        public SkillBasedAssigner(MatchRepository matchRepository, SteamworksApi steamworksApi) : this(matchRepository, steamworksApi, UnitTestLoggerCreator.CreateUnitTestLogger<SkillBasedAssigner>()) { }
 
         public async Task<(Team terrorists, Team counterTerrorists)> GetAssignedPlayers(IEnumerable<Player> players)
         {
@@ -130,7 +132,7 @@ namespace fairTeams.API
 
             try
             {
-                var steamapiStatistics = await SteamworksApi.ParsePlayerStatistics(player.SteamID);
+                var steamapiStatistics = await mySteamworksApi.ParsePlayerStatistics(player.SteamID);
                 var kdRating = new KDRating(steamapiStatistics);
                 player.Skill.AddRating(kdRating);
                 return player;

--- a/backend/fairTeams.API/Startup.cs
+++ b/backend/fairTeams.API/Startup.cs
@@ -1,5 +1,6 @@
 using fairTeams.Core;
 using fairTeams.DemoHandling;
+using fairTeams.Steamworks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
@@ -46,6 +47,8 @@ namespace fairTeams.API
             services.AddHostedService<MatchMakingDemoCollector>();
             services.AddHostedService<LocalDemoCollector>();
             services.AddHostedService<FTPDemoCollector>();
+
+            services.AddTransient<SteamworksApi>();
 
             services.AddScoped<ITeamAssigner, SkillBasedAssigner>();
         }

--- a/backend/fairTeams.Core/MatchRepository.cs
+++ b/backend/fairTeams.Core/MatchRepository.cs
@@ -53,6 +53,19 @@ namespace fairTeams.Core
             }
         }
 
+        public IList<MatchStatistics> GetAllMatchStatisticsForSteamId(long steamId)
+        {
+            Matches.Load();
+            var allMatchstatistics = Matches.SelectMany(x => x.PlayerResults);
+            var hasMatchesForSteamId = allMatchstatistics.Any(x => x.SteamID == steamId);
+            if (!hasMatchesForSteamId)
+            {
+                throw new NoMatchstatisticsFoundException(steamId);
+            }
+
+            return allMatchstatistics.Where(x => x.SteamID == steamId).ToList();
+        }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Match>()

--- a/backend/fairTeams.Core/MatchRepositoryException.cs
+++ b/backend/fairTeams.Core/MatchRepositoryException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace fairTeams.Core
+{
+    public class MatchRepositoryException : Exception
+    {
+        public MatchRepositoryException(string message) : base(message) { }
+    }
+
+    public class NoMatchstatisticsFoundException : MatchRepositoryException
+    {
+        public NoMatchstatisticsFoundException(long steamId) : base($"No match statistics found for steam ID: {steamId}") { }
+    }
+}

--- a/backend/fairTeams.DemoHandling/MatchMakingDemoCollector.cs
+++ b/backend/fairTeams.DemoHandling/MatchMakingDemoCollector.cs
@@ -117,6 +117,7 @@ namespace fairTeams.DemoHandling
             using var scope = myScopeFactory.CreateScope();
             var matchRepository = scope.ServiceProvider.GetRequiredService<MatchRepository>();
             var userRepository = scope.ServiceProvider.GetRequiredService<SteamUserRepository>();
+            var steamworksApi = scope.ServiceProvider.GetRequiredService<SteamworksApi>();
 
             var alreadyProcessedSharingCodes = matchRepository.Matches.Include("Demo").AsEnumerable().Select(x => x.Demo.ShareCode);
             var newSharingCodes = new List<string>();
@@ -125,7 +126,7 @@ namespace fairTeams.DemoHandling
 
             foreach (var user in steamUsers)
             {
-                var sharingCode = await SteamworksApi.GetNextMatchSharingCode(user.SteamID.ToString(), user.AuthenticationCode, user.LastSharingCode);
+                var sharingCode = await steamworksApi.GetNextMatchSharingCode(user.SteamID.ToString(), user.AuthenticationCode, user.LastSharingCode);
                 if (sharingCode.Equals("n/a") || sharingCode.Equals(user.LastSharingCode))
                 {
                     myLogger.LogTrace($"No new sharing code for Steam ID: {user.SteamID}");

--- a/backend/fairTeams.Steamworks.Tests/SteamworksApiTests.cs
+++ b/backend/fairTeams.Steamworks.Tests/SteamworksApiTests.cs
@@ -14,7 +14,9 @@ namespace fairTeams.Steamworks.Tests
         [Fact]
         public void ParseSteamUsernames_ValidSteamID_ReturnsFairTeamsAIUsername()
         {
-            var steamUsername = SteamworksApi.ParseSteamUsernames(new List<string> { myPrivateProfilePlayerSteamID }).Result.First().Value;
+            var steamworksApi = new SteamworksApi();
+
+            var steamUsername = steamworksApi.ParseSteamUsernames(new List<string> { myPrivateProfilePlayerSteamID }).Result.First().Value;
 
             Assert.Equal(myPrivateProfilePlayerSteamUsername, steamUsername);
         }
@@ -23,8 +25,9 @@ namespace fairTeams.Steamworks.Tests
         public void ParseSteamUsernames_InvalidSteamID_ReturnsNothing()
         {
             var invalidSteamID = "0";
+            var steamworksApi = new SteamworksApi();
 
-            var steamIDsWithUsername = SteamworksApi.ParseSteamUsernames(new List<string> { invalidSteamID }).Result;
+            var steamIDsWithUsername = steamworksApi.ParseSteamUsernames(new List<string> { invalidSteamID }).Result;
 
             Assert.Empty(steamIDsWithUsername);
         }
@@ -34,8 +37,9 @@ namespace fairTeams.Steamworks.Tests
         {
             var invalidSteamID = "0";
             var oneValidOneInvalidSteamID = new List<string> { myPrivateProfilePlayerSteamID, invalidSteamID };
+            var steamworksApi = new SteamworksApi();
 
-            var steamIDsWithUsername = SteamworksApi.ParseSteamUsernames(oneValidOneInvalidSteamID).Result;
+            var steamIDsWithUsername = steamworksApi.ParseSteamUsernames(oneValidOneInvalidSteamID).Result;
 
             Assert.Single(steamIDsWithUsername);
             Assert.Equal(myPrivateProfilePlayerSteamUsername, steamIDsWithUsername.First().Value);
@@ -44,7 +48,9 @@ namespace fairTeams.Steamworks.Tests
         [Fact]
         public async Task ParsePlayerStatistics_ProfileNotPublic_ThrowsProfileNotPublicException()
         {
-            var parseStatisticsTask = SteamworksApi.ParsePlayerStatistics(myPrivateProfilePlayerSteamID);
+            var steamworksApi = new SteamworksApi();
+
+            var parseStatisticsTask = steamworksApi.ParsePlayerStatistics(myPrivateProfilePlayerSteamID);
 
             await Assert.ThrowsAsync<ProfileNotPublicException>(() => parseStatisticsTask);
         }
@@ -59,8 +65,9 @@ namespace fairTeams.Steamworks.Tests
                 "total_damage_done",
                 "total_kills_bizon"
             };
+            var steamworksApi = new SteamworksApi();
 
-            var statistics = SteamworksApi.ParsePlayerStatistics(myPublicProfilePlayerSteamID).Result;
+            var statistics = steamworksApi.ParsePlayerStatistics(myPublicProfilePlayerSteamID).Result;
 
             Assert.True(statistics.Any());
 
@@ -76,7 +83,9 @@ namespace fairTeams.Steamworks.Tests
             var previousSharingCode = "CSGO-ndsnw-9jkUc-six5k-y2hcE-kosSJ";
             var authenticationToken = "7TDM-B27HW-THBQ";
 
-            var nextSharingCode = await SteamworksApi.GetNextMatchSharingCode(myPublicProfilePlayerSteamID, authenticationToken, previousSharingCode);
+            var steamworksApi = new SteamworksApi();
+
+            var nextSharingCode = await steamworksApi.GetNextMatchSharingCode(myPublicProfilePlayerSteamID, authenticationToken, previousSharingCode);
 
             Assert.Equal("CSGO-k2TXT-9rmts-XE8G2-yqGVu-FhnEM", nextSharingCode);
         }

--- a/backend/fairTeams.Steamworks/SteamworksApi.cs
+++ b/backend/fairTeams.Steamworks/SteamworksApi.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace fairTeams.Steamworks
 {
-    public static class SteamworksApi
+    public class SteamworksApi
     {
-        public static async Task<IDictionary<string, string>> ParseSteamUsernames(IList<string> steamIDs)
+        public virtual async Task<IDictionary<string, string>> ParseSteamUsernames(IList<string> steamIDs)
         {
             var commaDelimitedSteamIDs = string.Join(",", steamIDs);
 
@@ -33,7 +33,7 @@ namespace fairTeams.Steamworks
             return steamIDsWithUsernames;
         }
 
-        public static async Task<IList<Statistic>> ParsePlayerStatistics(string steamID)
+        public virtual async Task<IList<Statistic>> ParsePlayerStatistics(string steamID)
         {
             var webRequest = WebRequest.Create($"https://api.steampowered.com/ISteamUserStats/GetUserStatsForGame/v2/?appid=730&key={Settings.SteamWebAPIKey}&steamid={steamID}");
             webRequest.ContentType = "application/json";
@@ -54,7 +54,7 @@ namespace fairTeams.Steamworks
             }
         }
 
-        public static async Task<string> GetNextMatchSharingCode(string steamID, string authenticationCodeForUser, string previousSharingCodeForUser)
+        public virtual async Task<string> GetNextMatchSharingCode(string steamID, string authenticationCodeForUser, string previousSharingCodeForUser)
         {
             var webRequest = WebRequest.Create($"https://api.steampowered.com/ICSGOPlayers_730/GetNextMatchSharingCode/v1?key={Settings.SteamWebAPIKey}&steamid={steamID}&steamidkey={authenticationCodeForUser}&knowncode={previousSharingCodeForUser}");
             webRequest.ContentType = "application/json";


### PR DESCRIPTION
1. Attempt to get HLTV rating from past matches in our database
2. If no matches for a player have been analyzed try to get the overall K/D rating from the steamworks webapi
3. If the player's profile ain't public, i.e., we can't get the necessary statistics from the steamworks webapi, use a dummy score

Draft as it's still missing unit tests.