### PR TITLE
Catch more generic exception, as it's just re-wrapped anyhow.

### DIFF
--- a/backend/fairTeams.DemoAnalyzer/DemoReader.cs
+++ b/backend/fairTeams.DemoAnalyzer/DemoReader.cs
@@ -55,7 +55,7 @@ namespace fairTeams.DemoAnalyzer
             {
                 myDemoParser.ParseToEnd();
             }
-            catch (ArgumentOutOfRangeException e)
+            catch (Exception e)
             {
                 throw new DemoReaderException($"Unexpected exception thrown during demo analysis: {e.Message}");
             }


### PR DESCRIPTION
This ensures that the application won't crash, even with other unexpected exceptions.