### PR TITLE
Properly handle Windows-paths on linux runtimes

### DIFF
--- a/backend/fairTeams.DemoHandling/FTPDemoCollector.cs
+++ b/backend/fairTeams.DemoHandling/FTPDemoCollector.cs
@@ -81,7 +81,7 @@ namespace fairTeams.DemoHandling
             using var scope = myServiceProvider.CreateScope();
             var matchRepository = scope.ServiceProvider.GetService<MatchRepository>();
 
-            var existingDemoFileNames = matchRepository.Matches.Select(x => Path.GetFileName(x.Demo.FilePath)).ToList();
+            var existingDemoFileNames = matchRepository.Matches.Select(x => GetFileName(x.Demo.FilePath)).ToList();
             existingDemoFileNames.AddRange(Directory.EnumerateFiles(Settings.DemoWatchFolder).Where(x => x.EndsWith(".dem")));
             return allDemoFiles.Where(x => !existingDemoFileNames.Contains(x.Name)).ToList();
         }
@@ -131,5 +131,33 @@ namespace fairTeams.DemoHandling
                 }
             }
         }
+
+        private static string GetFileName(string path)
+        {
+            var isLinuxPath = IsLinuxPath(path);
+            var systemIsLinux = IsLinux();
+
+            // Path.GetFileName doesn't work for Windows paths running on a Linux system
+            // https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getfilename?view=net-5.0#System_IO_Path_GetFileName_System_String_
+            if (!isLinuxPath && systemIsLinux)
+            {
+                var splitWindowsPath = path.Split("\\").ToList();
+                return splitWindowsPath.Last();
+            }
+
+            return Path.GetFileName(path);
+        }
+
+        private static bool IsLinuxPath(string path)
+        {
+            return path.StartsWith("/");
+        }
+
+        public static bool IsLinux()
+        {
+            int p = (int) Environment.OSVersion.Platform;
+            return (p == 4) || (p == 6) || (p == 128);
+        }
+
     }
 }


### PR DESCRIPTION
The match repositories Demo FilePath parameter can contain Windows or Linux paths from matches parsed in the past.
Before downloading new matches from the FTP server, we check that file path against the files on the ftp server.
Unfortunately, Path.GetFileName doesn't work for Windows paths on Linux systems and therefore already-processed files aren't detected.