### PR TITLE
Backing up demo files

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - CSGO_FTP=
       - CSGO_FTP_USERNAME=
       - CSGO_FTP_PASSWORD=
+      - DEMO_FTP=
+      - DEMO_FTP_USERNAME=
+      - DEMO_FTP_PASSWORD=
       #- Logging__LogLevel__Default=Debug
     volumes:
       - ./databases:/root/.local/share/fairteamsai

--- a/backend/fairTeams.Core/PathExtensions.cs
+++ b/backend/fairTeams.Core/PathExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace fairTeams.Core
+{
+    public static class PathExtensions
+    {
+        public static string GetFileName(string path)
+        {
+            var isLinuxPath = IsLinuxPath(path);
+            var systemIsLinux = IsLinux();
+
+            // Path.GetFileName doesn't work for Windows paths running on a Linux system
+            // https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getfilename?view=net-5.0#System_IO_Path_GetFileName_System_String_
+            if (!isLinuxPath && systemIsLinux)
+            {
+                var splitWindowsPath = path.Split("\\").ToList();
+                return splitWindowsPath.Last();
+            }
+
+            return Path.GetFileName(path);
+        }
+
+        public static bool IsLinuxPath(string path)
+        {
+            return path.StartsWith("/");
+        }
+
+        public static bool IsLinux()
+        {
+            int p = (int)Environment.OSVersion.Platform;
+            return (p == 4) || (p == 6) || (p == 128);
+        }
+    }
+}

--- a/backend/fairTeams.Core/Settings.cs
+++ b/backend/fairTeams.Core/Settings.cs
@@ -10,8 +10,10 @@ namespace fairTeams.Core
         public static string CSGOServerFTP => GetEnvironmentVariableMachineAndProcess("CSGO_FTP");
         public static string CSGOServerFTPUsername => GetEnvironmentVariableMachineAndProcess("CSGO_FTP_USERNAME");
         public static string CSGOServerFTPPassword => GetEnvironmentVariableMachineAndProcess("CSGO_FTP_PASSWORD");
+        public static string DemoBackupFTP => GetEnvironmentVariableMachineAndProcess("DEMO_FTP");
+        public static string DemoBackupFTPUsername => GetEnvironmentVariableMachineAndProcess("DEMO_FTP_USERNAME");
+        public static string DemoBackupFTPPassword => GetEnvironmentVariableMachineAndProcess("DEMO_FTP_PASSWORD");
         public static string ApplicationFolder => Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "fairteamsai");
-
         public static string DemoWatchFolder => Path.Combine(ApplicationFolder, "demowatch");
 
         private static string GetEnvironmentVariableMachineAndProcess(string environmentVariable)

--- a/backend/fairTeams.DemoHandling/DemoBackuper.cs
+++ b/backend/fairTeams.DemoHandling/DemoBackuper.cs
@@ -1,0 +1,71 @@
+﻿using fairTeams.Core;
+using FluentFTP;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+
+namespace fairTeams.DemoHandling
+{
+    public sealed class DemoBackuper : IDisposable
+    {
+        private readonly ILogger<DemoBackuper> myLogger;
+        private readonly FtpClient myFtpClient;
+
+        public DemoBackuper(ILogger<DemoBackuper> logger)
+        {
+            myLogger = logger;
+
+            var ftpCredentials = new NetworkCredential(Settings.DemoBackupFTPUsername, Settings.DemoBackupFTPPassword);
+            myFtpClient = new FtpClient(Settings.DemoBackupFTP, 1818, ftpCredentials);
+            myFtpClient.AutoConnect();
+        }
+
+        public DemoBackuper() : this(UnitTestLoggerCreator.CreateUnitTestLogger<DemoBackuper>()) { }
+
+        public void BackupDemoFile(Demo demo)
+        {
+            BackupDemoFile(demo, false);
+        }
+
+        public void BackupDemoFile(Demo demo, bool deleteFileAfterUpload)
+        {
+            var filePath = demo.FilePath;
+
+            myLogger.LogInformation($"Trying to back up demo file ({filePath})");
+
+            if (!System.IO.File.Exists(filePath))
+            {
+                myLogger.LogWarning($"The file to be backed up does not exist: {filePath}");
+                throw new Exception($"The file to be backed up does not exist: {filePath}");
+            }
+
+            if (!myFtpClient.IsConnected)
+            {
+                myFtpClient.AutoConnect();
+            }
+
+            var remoteDemoFileName = $"{demo.Id}.dem";
+            var remoteFilePath = $"/csgo/{remoteDemoFileName}";
+
+            var successfulUpload = myFtpClient.UploadFile(filePath, remoteFilePath, FtpRemoteExists.Skip, false, FtpVerify.Retry);
+            if (successfulUpload.IsFailure())
+            {
+                myLogger.LogWarning($"Uploading the demo file ({remoteDemoFileName}) to the FTP failed.");
+                throw new Exception($"Uploading the demo file ({remoteDemoFileName}) to the FTP failed.");
+            }
+
+            myLogger.LogInformation($"Successfully backed up demo file {remoteDemoFileName}");
+
+            if (deleteFileAfterUpload)
+            {
+                myLogger.LogInformation($"Deleting backed up demo file {remoteDemoFileName}");
+                System.IO.File.Delete(filePath);
+            }
+        }
+
+        public void Dispose()
+        {
+            myFtpClient.Disconnect();
+        }
+    }
+}

--- a/backend/fairTeams.DemoHandling/FTPDemoCollector.cs
+++ b/backend/fairTeams.DemoHandling/FTPDemoCollector.cs
@@ -86,7 +86,7 @@ namespace fairTeams.DemoHandling
             using var scope = myServiceProvider.CreateScope();
             var matchRepository = scope.ServiceProvider.GetService<MatchRepository>();
 
-            var existingDemoFileNames = matchRepository.Matches.Select(x => GetFileName(x.Demo.FilePath)).ToList();
+            var existingDemoFileNames = matchRepository.Matches.Select(x => PathExtensions.GetFileName(x.Demo.FilePath)).ToList();
             existingDemoFileNames.AddRange(Directory.EnumerateFiles(Settings.DemoWatchFolder).Where(x => x.EndsWith(".dem")));
             return allDemoFiles.Where(x => !existingDemoFileNames.Contains(x.Name)).ToList();
         }
@@ -151,33 +151,5 @@ namespace fairTeams.DemoHandling
 
             return finishedDemoFiles;
         }
-
-        private static string GetFileName(string path)
-        {
-            var isLinuxPath = IsLinuxPath(path);
-            var systemIsLinux = IsLinux();
-
-            // Path.GetFileName doesn't work for Windows paths running on a Linux system
-            // https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getfilename?view=net-5.0#System_IO_Path_GetFileName_System_String_
-            if (!isLinuxPath && systemIsLinux)
-            {
-                var splitWindowsPath = path.Split("\\").ToList();
-                return splitWindowsPath.Last();
-            }
-
-            return Path.GetFileName(path);
-        }
-
-        private static bool IsLinuxPath(string path)
-        {
-            return path.StartsWith("/");
-        }
-
-        public static bool IsLinux()
-        {
-            int p = (int)Environment.OSVersion.Platform;
-            return (p == 4) || (p == 6) || (p == 128);
-        }
-
     }
 }

--- a/backend/fairTeams.DemoHandling/LocalDemoCollector.cs
+++ b/backend/fairTeams.DemoHandling/LocalDemoCollector.cs
@@ -1,4 +1,4 @@
-﻿using fairTeams.Core;
+using fairTeams.Core;
 using fairTeams.DemoAnalyzer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,15 +15,17 @@ namespace fairTeams.DemoHandling
     public sealed class LocalDemoCollector : IHostedService
     {
         private readonly IServiceScopeFactory myScopeFactory;
+        private readonly ILoggerFactory myLoggerFactory;
         private readonly ILogger<LocalDemoCollector> myLogger;
         private const int myEveryMinutesToTriggerProcessing = 30;
         private Timer myTimer;
         private readonly string myDemoWatchFolder;
 
-        public LocalDemoCollector(IServiceScopeFactory scopeFactory, ILogger<LocalDemoCollector> logger)
+        public LocalDemoCollector(IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
         {
             myScopeFactory = scopeFactory;
-            myLogger = logger;
+            myLoggerFactory = loggerFactory;
+            myLogger = loggerFactory.CreateLogger<LocalDemoCollector>();
 
             myDemoWatchFolder = Settings.DemoWatchFolder;
             if (!Directory.Exists(myDemoWatchFolder))
@@ -32,7 +34,7 @@ namespace fairTeams.DemoHandling
             }
         }
 
-        public LocalDemoCollector(IServiceScopeFactory scopeFactory) : this(scopeFactory, UnitTestLoggerCreator.CreateUnitTestLogger<LocalDemoCollector>()) { }
+        public LocalDemoCollector(IServiceScopeFactory scopeFactory) : this(scopeFactory, UnitTestLoggerCreator.CreateUnitTestLoggerFactory()) { }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
In case we want to/can use a score different from the HLTV, which might require different parameters, we will be able to re-analyze older demos if we back them up.

With this PR, the analyzed demo files (also when the analysis failed for debugging), are backed up to a given FTP server.